### PR TITLE
Bump version to 6.12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT FORCE_BUILD_VENDOR_PKG)
   find_package(ignition-math6 QUIET)
 endif()
 
-set(IGNITION_MATH6_TARGET_VERSION "6.9.2")
+set(IGNITION_MATH6_TARGET_VERSION "6.12.0")
 
 macro(build_ignition_math6)
   set(extra_cmake_args -DBUILD_TESTING=OFF)


### PR DESCRIPTION
This PR aims to bump the vendored version of `gz-math6` to `6.12` to match the version of the binary available in `Ubuntu 22.04 Jammy`.