### PR TITLE
Revert "Bump version to 6.12.0"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT FORCE_BUILD_VENDOR_PKG)
   find_package(ignition-math6 QUIET)
 endif()
 
-set(IGNITION_MATH6_TARGET_VERSION "6.12.0")
+set(IGNITION_MATH6_TARGET_VERSION "6.9.2")
 
 macro(build_ignition_math6)
   set(extra_cmake_args -DBUILD_TESTING=OFF)


### PR DESCRIPTION
Reverts gazebo-release/gz_math6_vendor#3

This caused failures on Windows, in both release mode and debug mode:

* https://ci.ros2.org/view/nightly/job/nightly_win_rel/2640/
* https://ci.ros2.org/view/nightly/job/nightly_win_deb/2687/