### PR TITLE
Forward CMAKE_PREFIX_PATH when building vendor package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@ set(IGNITION_MATH6_TARGET_VERSION "6.9.2")
 macro(build_ignition_math6)
   set(extra_cmake_args -DBUILD_TESTING=OFF)
 
+  if(DEFINED CMAKE_PREFIX_PATH)
+    list(APPEND extra_cmake_args "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}")
+  endif()
+
   if(DEFINED CMAKE_BUILD_TYPE)
     list(APPEND extra_cmake_args -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
   endif()


### PR DESCRIPTION
When building with colcon, CMAKE_PREFIX_PATH is set as an environment variable. During the system package builds however, it's set as a CMake variable which will need to be explicitly forwarded to the vendor package build.

This should resolve the build failures for Iron on RHEL 9, which started failing when I disabled the tests. It appears that one or more of the test dependencies of this package modified the `PATH` variable, which was allowing CMake to find dependencies of this package before.

This change could probably be backported to other released distros, but we're only experiencing pain on Iron.